### PR TITLE
Change Upcoming Workshops layout. Add text styles.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,8 +13,6 @@
 	--accent-2: #b8007c;
 	--accent-3: #ef7cb6;
 	--accent-4: #fca63d;
-  /* --bs-navbar-color: var(--accent-1);
-  --bs-navbar-hover-color: var(--accent-4); */
 }
 
 ::selection {
@@ -101,8 +99,6 @@ h1 {
 
 .page_divider {
 	border: 1px dotted var(--accent-4);
-	text-align: center;
-	/* margin: 20px 0; */
 }
 
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     </header>
 
     <main class="container-fluid">
-  
+      
       <section class="container p-3">
           <div class="row">
             <div class="col-12 col-lg-6">
@@ -101,31 +101,31 @@
           </div>
       </section>
 
-      <div class="page_divider"></div>
+      <div class="page_divider container"></div>
 
       <section class="container p-3">
         <h2 class="heading_2">Upcoming Workshops</h2>
         <p>
           Workshops are open to SWSG guild members. Due to COVID-19, in-person workshop attendance will require you to be masked.
         </p>
-        <div>
-          <div>
-            <img src="./img/stephenie-gaustad.webp" alt="Stephenie Gaustad">
+        <div class="container row mt-2">
+          <div class="col-md-auto">
+            <img src="./img/stephenie-gaustad.webp" alt="Stephenie Gaustad" class="">
           </div>
-          <div>
-            <p>
+          <div class="col-md">
+            <p class="fw-bold">
               Date: September 27, 2022
             </p>
-            <p>
+            <p class="fw-bold">
               Time: Following the guild meeting.
             </p>
-            <p>
+            <p class="fw-bold">
               Location: Shepard Garden and Arts Center, 3300 McKinley Blvd, Sacramento, CA; Zoom
             </p>
-            <p>
+            <p class="fw-bold">
               Speaker: Stephenie Gaustad
             </p>
-            <p>
+            <p class="fw-bold">
               Topic: Hemp From the Field to Fiber
             </p>
             <p>      
@@ -144,24 +144,24 @@
           </div>
         </div>
       
-        <div>
-          <div>
+        <div class="container row mt-2">
+          <div class="col-md-auto">
             <img src="./img/sharlet-elms.webp" alt="Sharlet Elms">
           </div>
-          <div>
-            <p>
+          <div class="col-md">
+            <p class="fw-bold">
               Date: October 26-27, 2022
             </p>
-            <p>
+            <p class="fw-bold">
               Time: 9:00am to 3:00pm
             </p>
-            <p>
+            <p class="fw-bold">
               Location: Northminster Presbyterian Church, 3235 Pope Ave, Sacramento, CA
             </p>
-            <p>
+            <p class="fw-bold">
               Speaker: Sharlet Elms
             </p>
-            <p>
+            <p class="fw-bold">
               Topic: 4 to 8 Shafts, Advanced Beginner to Intermediate Weavers
             </p>
             <p>      
@@ -178,7 +178,7 @@
         </div>
       </section>
 
-      <div class="page_divider"></div>
+      <div class="page_divider container"></div>
 
       <section class="container p-3">
         <h2 class="heading_2">Announcements</h2>


### PR DESCRIPTION
**Changes:**
- Added Bootstrap column classes to the "Upcoming Workshops" section to have a stacked layout on smaller screens and a side-by-side layout on screens larger than the medium breakpoint
- Added the Bootstrap `fw-bold` class to the date, time, location, speaker, and topic text paragraphs
- Added Bootstrap `.container` to the `page_divider` `div`s so that they would change width with the rest of the page content


Closes #3.